### PR TITLE
Fix undefined index notice when option is not set in settings.

### DIFF
--- a/page-for-post-type.php
+++ b/page-for-post-type.php
@@ -79,11 +79,17 @@ class Page_For_Post_Type {
 
 		$value = intval( $args['value'] );
 
+        $default = $args['post_type']->name;
+
+        if ( isset( $this->original_slugs[ $args['post_type']->name ] ) ) {
+            $default = $this->original_slugs[ $args['post_type']->name ];
+        }
+
 		wp_dropdown_pages( array(
 			'name'             => esc_attr( $args['name'] ),
 			'id'               => esc_attr( $args['name'] . '_dropdown' ),
 			'selected'         => $value,
-			'show_option_none' => sprintf( __( 'Default (/%s/)' ), $this->original_slugs[ $args['post_type']->name ] ),
+			'show_option_none' => sprintf( __( 'Default (/%s/)' ), $default ),
 		) );
 
 	}


### PR DESCRIPTION
When no option is selected yet in Settings > Reading, a notice shows up for every select field:

`Notice: Undefined index: example in /wp-content/plugins/page-for-post-type/page-for-post-type.php on line 86`

This pull request checks for the option to exist before it overwrites the default name.