### PR TITLE
Add action that enables custom rewrite rules to be added

### DIFF
--- a/page-for-post-type.php
+++ b/page-for-post-type.php
@@ -259,6 +259,8 @@ class Page_For_Post_Type {
 				}
 			}
 
+			do_action("page_for_{$post_type}_rewrite_rules", $archive_slug, $post_type, $args);
+
 			$permastruct_args         = $args->rewrite;
 			$permastruct_args['feed'] = $permastruct_args['feeds'];
 


### PR DESCRIPTION
This PR adds an action hook after the main page rewrite rules have been added, that allows setting up of extra rewrite rules based on the new rewrite slug that's defined in this plugin. 

Use case 1:
I need to add an extra rewrite that allows the year to be appended to the end of the url to browse the 'portfolio' cpt archives by year. 

    function my_page_for_portfolio_rewrite_rules($archive_slug, $post_type, $args) {
        global $wp_rewrite;
        add_rewrite_rule( "{$archive_slug}/([0-9]{4})/?$", "index.php?post_type=$post_type" . 'year=$matches[1]' .  'top' );
        if ( $args->rewrite['pages'] ) {
            add_rewrite_rule( "{$archive_slug}/([0-9]{4})/{$wp_rewrite->pagination_base}/([0-9]{1,})/?$", "index.php?post_type=$post_type" . '&year=$matches[1]' . '&paged=$matches[2]', 'top' );
        }
    }
    add_action('page_for_portfolio_rewrite_rules', 'my_page_for_portfolio_rewrite_rules', 10, 3);

Thanks,
Tim